### PR TITLE
Add MCP basic agent sample

### DIFF
--- a/contributing/samples/mcp_basic_agent/README.md
+++ b/contributing/samples/mcp_basic_agent/README.md
@@ -1,0 +1,17 @@
+# MCP Basic Agent
+
+This sample shows how to integrate an ADK agent with a Model Context Protocol (MCP) tool.
+It launches the MCP filesystem server via `npx` and allows the agent to read files
+within this directory.
+
+## Running
+
+1. Ensure you have Node and `npx` installed.
+2. Start the ADK Web UI using this agent:
+
+   ```bash
+   adk web --agent-path contributing/samples/mcp_basic_agent
+   ```
+
+The agent will automatically start the MCP server and expose read-only file
+operations such as `read_file` and `list_directory`.

--- a/contributing/samples/mcp_basic_agent/agent.py
+++ b/contributing/samples/mcp_basic_agent/agent.py
@@ -1,0 +1,37 @@
+import os
+
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.tools.mcp_tool import StdioConnectionParams
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
+from mcp import StdioServerParameters
+
+_allowed_path = os.path.dirname(os.path.abspath(__file__))
+
+root_agent = LlmAgent(
+    model="gemini-2.0-flash",
+    name="mcp_filesystem_agent",
+    instruction=f"""
+Use the provided MCP tools to read files under {_allowed_path}.
+Only read operations are allowed.
+""",
+    tools=[
+        MCPToolset(
+            connection_params=StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command="npx",
+                    args=["-y", "@modelcontextprotocol/server-filesystem", _allowed_path],
+                ),
+                timeout=5,
+            ),
+            tool_filter=[
+                "read_file",
+                "read_multiple_files",
+                "list_directory",
+                "directory_tree",
+                "search_files",
+                "get_file_info",
+                "list_allowed_directories",
+            ],
+        )
+    ],
+)


### PR DESCRIPTION
## Summary
- add example agent using MCP filesystem server
- document how to run the MCP sample

## Testing
- `pytest ./tests/unittests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6842b665e574832cbb1c6913580aaf36